### PR TITLE
チャット画面からグループ編集画面へのパス指定を修正

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,7 +13,6 @@ class MessagesController < ApplicationController
         format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
         format.json 
       end 
-      # binding.pry 
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,7 +15,7 @@
               - @group.users.each do |user|
                 = user.name
           %div.contents__header__edit-btn{"data-turbolinks": "false"}
-            = link_to edit_group_path(current_user) do
+            = link_to edit_group_path(@group.id) do
               %p.contents__header__edit-btn__letter Edit
 
         %div.contents__chat


### PR DESCRIPTION
# What
チャット画面からグループ編集画面へのリンク（Editボタン）のパス指定に誤りがあったため、修正。

# Why
グループ編集を正常に行えるようにするため。